### PR TITLE
[BUG FIX] Fixed issue with index out-of-range on empty search

### DIFF
--- a/pages/main_page.go
+++ b/pages/main_page.go
@@ -169,7 +169,9 @@ func setUpMangaListTable(pages *tview.Pages, table *tview.Table, params *url.Val
 
 		// When user presses ENTER on a manga row, they are redirected to the manga page.
 		table.SetSelectedFunc(func(row, column int) {
-			ShowMangaPage(pages, &(mangaList.Results[row-1]))
+      if(len(mangaList.Results) != 0) {
+		    ShowMangaPage(pages, &(mangaList.Results[row-1]))
+      }
 		})
 
 		// Add each entry to the table.

--- a/pages/main_page.go
+++ b/pages/main_page.go
@@ -169,9 +169,9 @@ func setUpMangaListTable(pages *tview.Pages, table *tview.Table, params *url.Val
 
 		// When user presses ENTER on a manga row, they are redirected to the manga page.
 		table.SetSelectedFunc(func(row, column int) {
-      if(len(mangaList.Results) != 0) {
-		    ShowMangaPage(pages, &(mangaList.Results[row-1]))
-      }
+			if len(mangaList.Results) != 0 {
+				ShowMangaPage(pages, &(mangaList.Results[row-1]))
+			}
 		})
 
 		// Add each entry to the table.


### PR DESCRIPTION
## Issue
When the search is supplied an empty string, the table still allows the user to try and access the manga page. This leads to an index out-of-range issue as mangaList.Results is empty.

## Fix
Add a simple check before displaying the manga page to ensure mangaList.Results is not empty.