### PR TITLE
Update download_utils.go

### DIFF
--- a/pages/download_utils.go
+++ b/pages/download_utils.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/darylhjd/mangodex"
 	"github.com/rivo/tview"
@@ -160,14 +161,18 @@ func saveAsZipFolder(chapterFolder string) error {
 			_ = fileOriginal.Close()
 		}()
 
-		// Create a designated file in the zip folder for the current image.
-		fileZip, err := w.Create(d.Name())
+		//Create file in zip with file header
+		fh := new(zip.FileHeader)
+		fh.Modified = time.Now()
+		fh.Name = d.Name()
+
+		wh, err := w.CreateHeader(fh)
 		if err != nil {
 			return err
 		}
 
 		// Copy the original file into its designated file in the zip archive
-		_, err = io.Copy(fileZip, fileOriginal)
+		_, err = io.Copy(wh, fileOriginal)
 		if err != nil {
 			return err
 		}

--- a/pages/download_utils.go
+++ b/pages/download_utils.go
@@ -161,18 +161,21 @@ func saveAsZipFolder(chapterFolder string) error {
 			_ = fileOriginal.Close()
 		}()
 
-		//Create file in zip with file header
-		fh := new(zip.FileHeader)
-		fh.Modified = time.Now()
-		fh.Name = d.Name()
-
-		wh, err := w.CreateHeader(fh)
+		// Create designated file in zip folder for current image. 
+		// Use custom header to set modified timing.
+		// This fixes zip parsing issues in certain situations.
+		fh := zip.FileHeader{
+			Name: d.Name(),
+			Modified: time.Now(),
+			Method: zip.Deflate, // Consistent with w.Create() source code.
+		}
+		fileZip, err := w.CreateHeader(&fh)
 		if err != nil {
 			return err
 		}
 
-		// Copy the original file into its designated file in the zip archive
-		_, err = io.Copy(wh, fileOriginal)
+		// Copy the original file into its designated file in the zip archive.
+		_, err = io.Copy(fileZip, fileOriginal)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Changes zip writer to add a header to files. Without including the date modified of the image files, the manga self-hoster I use, "mango" fails to parse the archive.