### PR TITLE
feat: add config for guest mode

### DIFF
--- a/app/core/CONFIG.md
+++ b/app/core/CONFIG.md
@@ -63,3 +63,13 @@ Set to `true` if you want your chapter downloads to be compressed into a zip fol
 
 Valid options are `zip` or `cbz`. This is ignored if `asZip` is set to `false`. Any other empty/invalid option will
 default to `zip`.
+
+
+### Guest Login
+
+- `guestLogin`
+
+Valid options are `true` or `false`. It is `false` by default.
+
+Set to `true` if you want to skip the login screen and login as guest always.
+

--- a/app/core/CONFIG.md
+++ b/app/core/CONFIG.md
@@ -64,10 +64,9 @@ Set to `true` if you want your chapter downloads to be compressed into a zip fol
 Valid options are `zip` or `cbz`. This is ignored if `asZip` is set to `false`. Any other empty/invalid option will
 default to `zip`.
 
+### Guest Mode
 
-### Guest Login
-
-- `guestLogin`
+- `guestMode`
 
 Valid options are `true` or `false`. It is `false` by default.
 

--- a/app/core/config.go
+++ b/app/core/config.go
@@ -16,7 +16,7 @@ var (
 	languages       = []string{"en"}
 	downloadQuality = "data"
 	zipType         = "zip"
-	guestLogin      = false
+	guestMode       = false
 )
 
 // UserConfig : This struct contains te user configurable settings.
@@ -28,7 +28,7 @@ type UserConfig struct {
 	ForcePort443    bool     `json:"forcePort443"`
 	AsZip           bool     `json:"asZip"`
 	ZipType         string   `json:"zipType"`
-	GuestLogin      bool     `json:"guestLogin"`
+	GuestMode       bool     `json:"guestMode"`
 }
 
 // loadConfiguration : Reads any user configuration settings and will create a default one if it does not exist.

--- a/app/core/config.go
+++ b/app/core/config.go
@@ -16,6 +16,7 @@ var (
 	languages       = []string{"en"}
 	downloadQuality = "data"
 	zipType         = "zip"
+	guestLogin      = false
 )
 
 // UserConfig : This struct contains te user configurable settings.
@@ -27,6 +28,7 @@ type UserConfig struct {
 	ForcePort443    bool     `json:"forcePort443"`
 	AsZip           bool     `json:"asZip"`
 	ZipType         string   `json:"zipType"`
+	GuestLogin      bool     `json:"guestLogin"`
 }
 
 // loadConfiguration : Reads any user configuration settings and will create a default one if it does not exist.

--- a/app/core/credentials.go
+++ b/app/core/credentials.go
@@ -42,18 +42,28 @@ func (m *MangaDesk) loadCredentials() error {
 // If they are, then read it, and attempt to refresh the token.
 // Will return error if any steps fail (no stored credentials, authentication failed).
 func (m *MangaDesk) restoreSession() error {
+	// We do not need to wait/show a session-related messages
+	// if the user logs in as guest.
+	isGuest := m.Config.GuestLogin
+
 	// Try to read stored credential file.
 	if err := m.loadCredentials(); err != nil { // If error, then user was not originally logged in.
-		fmt.Println("No past session, redirecting to login...")
-		time.Sleep(time.Millisecond * 750)
+		if !isGuest {
+			fmt.Println("No past session, redirecting to login...")
+			time.Sleep(time.Millisecond * 750)
+		}
 		return err
 	}
 
-	fmt.Println("Attempting session restore...")
+	if !isGuest {
+		fmt.Println("Attempting session restore...")
+	}
 	// Do a refresh of the token to keep it up to date. If the token has already expired, user needs to log in again.
 	if err := m.Client.Auth.RefreshSessionToken(); err != nil {
-		fmt.Println("Session expired. Please login again.")
-		time.Sleep(time.Millisecond * 750)
+		if !isGuest {
+			fmt.Println("Session expired. Please login again.")
+			time.Sleep(time.Millisecond * 750)
+		}
 		return err
 	}
 	return nil

--- a/app/core/credentials.go
+++ b/app/core/credentials.go
@@ -44,26 +44,23 @@ func (m *MangaDesk) loadCredentials() error {
 func (m *MangaDesk) restoreSession() error {
 	// We do not need to wait/show a session-related messages
 	// if the user logs in as guest.
-	isGuest := m.Config.GuestLogin
+	if !m.Config.GuestLogin {
+		return nil
+	}
 
 	// Try to read stored credential file.
 	if err := m.loadCredentials(); err != nil { // If error, then user was not originally logged in.
-		if !isGuest {
-			fmt.Println("No past session, redirecting to login...")
-			time.Sleep(time.Millisecond * 750)
-		}
+		fmt.Println("No past session, redirecting to login...")
+		time.Sleep(time.Millisecond * 750)
 		return err
 	}
 
-	if !isGuest {
-		fmt.Println("Attempting session restore...")
-	}
+	fmt.Println("Attempting session restore...")
+
 	// Do a refresh of the token to keep it up to date. If the token has already expired, user needs to log in again.
 	if err := m.Client.Auth.RefreshSessionToken(); err != nil {
-		if !isGuest {
-			fmt.Println("Session expired. Please login again.")
-			time.Sleep(time.Millisecond * 750)
-		}
+		fmt.Println("Session expired. Please login again.")
+		time.Sleep(time.Millisecond * 750)
 		return err
 	}
 	return nil

--- a/app/core/credentials.go
+++ b/app/core/credentials.go
@@ -44,7 +44,7 @@ func (m *MangaDesk) loadCredentials() error {
 func (m *MangaDesk) restoreSession() error {
 	// We do not need to wait/show a session-related messages
 	// if the user logs in as guest.
-	if !m.Config.GuestLogin {
+	if m.Config.GuestMode {
 		return nil
 	}
 

--- a/app/core/credentials.go
+++ b/app/core/credentials.go
@@ -55,7 +55,6 @@ func (m *MangaDesk) restoreSession() error {
 	}
 
 	fmt.Println("Attempting session restore...")
-
 	// Do a refresh of the token to keep it up to date. If the token has already expired, user needs to log in again.
 	if err := m.Client.Auth.RefreshSessionToken(); err != nil {
 		fmt.Println("Session expired. Please login again.")

--- a/app/service/service.go
+++ b/app/service/service.go
@@ -18,12 +18,12 @@ func Start() {
 		PageHolder: tview.NewPages(),
 	}
 
+	// Show appropriate screen based on restore session result.
 	if err := core.App.Initialise(); err != nil {
 		ui.ShowLoginPage()
 	} else {
 		ui.ShowMainPage()
 	}
-
 	log.Println("Initialised starting screen.")
 	ui.SetUniversalHandlers()
 

--- a/app/service/service.go
+++ b/app/service/service.go
@@ -18,12 +18,14 @@ func Start() {
 		PageHolder: tview.NewPages(),
 	}
 
-	// Show appropriate screen based on restore session result.
-	if err := core.App.Initialise(); err != nil {
+	// Show appropriate screen based on restore session result. If user has
+	// guestLogin on their config, we don't show the login page.
+	if err := core.App.Initialise(); err != nil && !core.App.Config.GuestLogin {
 		ui.ShowLoginPage()
 	} else {
 		ui.ShowMainPage()
 	}
+
 	log.Println("Initialised starting screen.")
 	ui.SetUniversalHandlers()
 

--- a/app/service/service.go
+++ b/app/service/service.go
@@ -18,9 +18,7 @@ func Start() {
 		PageHolder: tview.NewPages(),
 	}
 
-	// Show appropriate screen based on restore session result. If user has
-	// guestLogin on their config, we don't show the login page.
-	if err := core.App.Initialise(); err != nil && !core.App.Config.GuestLogin {
+	if err := core.App.Initialise(); err != nil {
 		ui.ShowLoginPage()
 	} else {
 		ui.ShowMainPage()


### PR DESCRIPTION
Addresses #77.

I don't have a mangadex account, so I always end up skipping the login screen and logging in as a guest. This pull request adds a config flag to always log in as a guest by skipping the login screen.

I manually tested these changes by running `go build`, editing my config, and then seeing the result. Is this a good enough testing story?

I am a go newbie, so apologies for any weird-nesses in my code! Lmk if you'd like any changes!

Thanks,
Enoumy