### PR TITLE
feat: add Void Linux install/uninstall instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,14 @@ Mangadesk is available through the [MPR](https://mpr.makedeb.org/packages/mangad
 $ una install mangadesk
 ```
 
+### Void Linux
+
+Mangadesk is available through the official Void repositories and can be installed via XBPS:
+
+```cmd
+$ xbps-install -S mangadesk
+```
+
 ## Uninstall ❌
 
 To uninstall, simply delete the executable and its related folders and files.
@@ -77,6 +85,14 @@ Uninstall with a MPR helper or with APT:
 
 ```cmd
 $ una remove mangadesk
+```
+
+### Void Linux
+
+Uninstall with XBPS:
+
+```cmd
+$ xbps-remove -R mangadesk
 ```
 
 ## Usage ✍


### PR DESCRIPTION
Hello,

Mangadesk is now published in the official Void Linux repositories.
Related PR : https://github.com/void-linux/void-packages/pull/44464

This PR is intended to provide some instructions for installing the package on the Void Linux distribution.